### PR TITLE
Updated getDecimal(color) to not call String.format

### DIFF
--- a/src/main/java/fishcute/celestial/util/Util.java
+++ b/src/main/java/fishcute/celestial/util/Util.java
@@ -415,7 +415,7 @@ public class Util {
     }
 
     public static int getDecimal(Color color) {
-        return getDecimal(String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue()));
+        return getDecimal("#" + Integer.toHexString(color.getRed()) + Integer.toHexString(color.getGreen()) + Integer.toHexString(color.getBlue()));
     }
 
     public static double generateRandomDouble(double min, double max) {


### PR DESCRIPTION
I noticed getDecimal's call to String.format was causing a lot of slowdown, especially when running alongside Sodium/Rubidium, as those seem to make a lot of calls to biome and sky colors. Converting the RBG values to a hex string using Integer.toHexString and concatenation gets back 10 to 20 fps.